### PR TITLE
Use https in github repo SRC_URIS

### DIFF
--- a/recipes-qt/examples/qt5-opengles2-test_git.bb
+++ b/recipes-qt/examples/qt5-opengles2-test_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "qtbase qtsensors"
 # Depends on gles2 enabled and that's not default configuration
 EXCLUDE_FROM_WORLD = "1"
 
-SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git"
+SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git;protocol=https"
 SRCREV = "938390507054ed1258345f70ed55770d2fe56176"
 S = "${WORKDIR}/git"
 

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=5c917f6ce94ceb8d8d5e16e2fca5b9ad"
 
 inherit qmake5 qmake5_paths
 
-SRC_URI = "git://github.com/maliit/framework.git;branch=master \
+SRC_URI = "git://github.com/maliit/framework.git;branch=master;protocol=https \
            file://0001-Fix-MALIIT_INSTALL_PRF-to-allow-the-build-with-opene.patch \
            file://maliit-server.desktop \
            file://0001-config.pri-Use-O1-optimization-in-DEBUG-flags.patch \

--- a/recipes-qt/maliit/maliit-plugins-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-plugins-qt5_git.bb
@@ -10,7 +10,7 @@ DEPENDS = "maliit-framework-qt5"
 
 RDEPENDS_${PN} += "qtsvg-plugins"
 
-SRC_URI = "git://github.com/maliit/plugins.git;branch=master"
+SRC_URI = "git://github.com/maliit/plugins.git;branch=master;protocol=https"
 
 SRCREV = "c6a348592607248a771a3dde5a0e33dc3c433a2a"
 PV = "0.99.0+git${SRCPV}"

--- a/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
+++ b/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
@@ -16,7 +16,7 @@ DEPENDS = "qtbase"
 # Needed with gcc-5.2 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65801
 CXXFLAGS += "-Wno-narrowing"
 
-SRC_URI = "git://github.com/nemomobile/qt5-plugin-generic-vboxtouch.git"
+SRC_URI = "git://github.com/nemomobile/qt5-plugin-generic-vboxtouch.git;protocol=https"
 SRCREV = "3f2bdb5a1d346f02d5ab185522271ba2288a42bb"
 S = "${WORKDIR}/git/vboxtouch"
 

--- a/recipes-qt/tufao/tufao_1.3.10.bb
+++ b/recipes-qt/tufao/tufao_1.3.10.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://COPYING.LESSER;md5=4fbd65380cdd255951079008b364516c"
 DEPENDS = "qtbase"
 
 SRCREV = "ad505c32d0ba14c3c616de8ba4c7eb79396c20a6"
-SRC_URI = "git://github.com/vinipsmaker/tufao.git;protocol=http;branch=1.x \
+SRC_URI = "git://github.com/vinipsmaker/tufao.git;protocol=http;branch=1.x;protocol=https \
            file://build-Fix-mkspecs-and-CMake-module-install-directori.patch"
 
 # This includes bugfixes from 1.x branch


### PR DESCRIPTION
Github is moving to deprecate the git protocol in its repos. Update all
github URIs to use the `https` protocol.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

---

This patchset was partially generated using a backported version of the [`convert-srcuri.py`](https://git.openembedded.org/openembedded-core/tree/scripts/contrib/convert-srcuri.py?id=5e2fc4676b8944fc1d36d567bb2d1ff4cff32294) script that Richard Purdie authored for OE upstream, when the community was mass-converting recipes over to use `protocol=https`. I removed the additional logic from the script to append `branch=master`, because it was more hassle than it was worth. I ran the script against this layer and manually checked the results. The script caught 95% of conversions, and I manually fixed the rest.

# Testing
1. Applied the "warning" commit from [ni/bitbake #6](https://github.com/ni/bitbake/pull/6).
2. Ran `bitbake -n ${targets}` using all the recipe targets which we currently build in the `NIOpenEmbedded` component, and recorded the *many* recipes which failed.
3. Applied this patchset to the meta layer.
4. Cleaned and re-ran bitbake and confirmed that there are now no recipes which warn about using the git protocol with github.

@ni/rtos 