### PR TITLE
convert git://github.com SRC_URIs to use https

### DIFF
--- a/recipes-qt/examples/qt5-opengles2-test_git.bb
+++ b/recipes-qt/examples/qt5-opengles2-test_git.bb
@@ -12,7 +12,7 @@ DEPENDS = "qtbase qtsensors"
 # Depends on gles2 enabled and that's not default configuration
 EXCLUDE_FROM_WORLD = "1"
 
-SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git"
+SRC_URI = "git://github.com/smk-embedded/qt5-opengles2-test.git;protocol=https"
 SRCREV = "938390507054ed1258345f70ed55770d2fe56176"
 S = "${WORKDIR}/git"
 

--- a/recipes-qt/maliit/maliit-framework-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-framework-qt5_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.LGPL;md5=5c917f6ce94ceb8d8d5e16e2fca5b9ad"
 
 inherit qmake5 qmake5_paths
 
-SRC_URI = "git://github.com/maliit/framework.git;branch=master \
+SRC_URI = "git://github.com/maliit/framework.git;branch=master;protocol=https \
            file://0001-Fix-MALIIT_INSTALL_PRF-to-allow-the-build-with-opene.patch \
            file://maliit-server.desktop \
            file://0001-config.pri-Use-O1-optimization-in-DEBUG-flags.patch \

--- a/recipes-qt/maliit/maliit-plugins-qt5_git.bb
+++ b/recipes-qt/maliit/maliit-plugins-qt5_git.bb
@@ -10,7 +10,7 @@ DEPENDS = "maliit-framework-qt5"
 
 RDEPENDS_${PN} += "qtsvg-plugins"
 
-SRC_URI = "git://github.com/maliit/plugins.git;branch=master \
+SRC_URI = "git://github.com/maliit/plugins.git;branch=master;protocol=https \
            file://0001-Do-not-use-tr1-namespace.patch \
           "
 

--- a/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
+++ b/recipes-qt/qt5/qt5-plugin-generic-vboxtouch_git.bb
@@ -16,7 +16,7 @@ DEPENDS = "qtbase"
 # Needed with gcc-5.2 https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65801
 CXXFLAGS += "-Wno-narrowing"
 
-SRC_URI = "git://github.com/nemomobile/qt5-plugin-generic-vboxtouch.git \
+SRC_URI = "git://github.com/nemomobile/qt5-plugin-generic-vboxtouch.git;protocol=https \
            file://0001-VirtualboxTouchScreenHandler-initialize-m_mouse.patch;patchdir=.. \
            file://0001-include-errno.h-for-errno-definition.patch;patchdir=.. \
            "


### PR DESCRIPTION
Github is moving to deprecate the git:// protocol for repo access. Use a
modified version of the upstream covert-srcuris.py script to find and
fixup github source URIs in-bulk.

Signed-off-by: Alex Stewart <alex.stewart@ni.com>

----

# Testing
Ran the `do_fetch` tasks of `packagefeed-ni-core` and confirmed that bitbake does not report any recipes as using a `git://github.com` URI.

@ni/rtos