### PR TITLE
qt5: Use nobranch=1 as upstream deleted branch

### DIFF
--- a/recipes-qt/qt5/qt5-git.inc
+++ b/recipes-qt/qt5/qt5-git.inc
@@ -2,12 +2,12 @@
 # Copyright (C) 2013-2020 Martin Jansa <martin.jansa@gmail.com>
 
 QT_MODULE ?= "${BPN}"
-QT_MODULE_BRANCH ?= "5.15.2"
+QT_MODULE_BRANCH ?= "5.15"
 QT_MODULE_BRANCH_PARAM ?= "branch=${QT_MODULE_BRANCH}"
 
 # each module needs to define valid SRCREV
 SRC_URI = " \
-    ${QT_GIT}/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL} \
+    ${QT_GIT}/${QT_MODULE}.git;name=${QT_MODULE};${QT_MODULE_BRANCH_PARAM};protocol=${QT_GIT_PROTOCOL};nobranch=1 \
 "
 
 CVE_PRODUCT = "qt"


### PR DESCRIPTION
Upstream deleted 5.15.2 branch and the commits referenced in SRCREV don't belong to any branch. So use "nobranch=1" to prevent build failure.

Also updated branch name to 5.15 - which is functionally not required but is better than referencing a non-existent branch.

Bug: https://github.com/ni/nilrt/issues/206

### Testing
- [x] Build qtbase
- [x] Build packagefeed-ni-core