### PR TITLE
meta-qt5: Currency merge with upstream master branch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield"
+LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 


### PR DESCRIPTION
This is the periodic currency merge with upstream `master` branch as no `scarthgap` branch exists yet.

Did the merge using `upstream_merge.sh` script. No conflicts.

WI: [AB#2468923](https://dev.azure.com/ni/DevCentral/_workitems/edit/2468923)

### Testing
- [x] bitbake packagefeed-ni-core
- [x] bitbake packagegroup-ni-desirable
- [x] bitbake package-index && bitbake nilrt-base-system-image
- [x] Installed BSI on a VM and verified it boots

### Note to maintainers
Please complete this merge manually to avoid upstream hashes being changed by GH.