### PR TITLE
Cherry-pick commits from upstream to fix QA errors

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -29,7 +29,7 @@ LAYERVERSION_qt5-layer = "1"
 
 LAYERDEPENDS_qt5-layer = "core openembedded-layer"
 
-LAYERSERIES_COMPAT_qt5-layer = "dunfell gatesgarth hardknott honister kirkstone langdale mickledore nanbield scarthgap"
+LAYERSERIES_COMPAT_qt5-layer = "scarthgap"
 
 LICENSE_PATH += "${LAYERDIR}/licenses"
 

--- a/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
+++ b/recipes-qt/packagegroups/nativesdk-packagegroup-qt5-toolchain-host.bb
@@ -3,7 +3,8 @@
 SUMMARY = "Host packages for the Qt5 standalone SDK or external toolchain"
 LICENSE = "MIT"
 
-inherit packagegroup nativesdk
+inherit packagegroup
+inherit_defer nativesdk
 
 PACKAGEGROUP_DISABLE_COMPLEMENTARY = "1"
 


### PR DESCRIPTION
Our PR to fix QA errors https://github.com/meta-qt5/meta-qt5/pull/557 ended up in upstream's `master-next` but it is not clear how long it'd take to get merged to `master`.

So just cherry-picking the two commits.

### Testing
- [x] `bitbake packagefeed-ni-core`