### PR TITLE
[next] Cherry-pick fixes for qtbase warnings

### DIFF
--- a/recipes-qt/qt5/qtbase/0028-Remove-host-paths-from-qmake.patch
+++ b/recipes-qt/qt5/qtbase/0028-Remove-host-paths-from-qmake.patch
@@ -1,0 +1,43 @@
+Remove host paths from qmake
+The host paths are not useful on the target and may cause security concerns.
+
+Instead set them to extprefix or just plain "/" to at least remove host paths.
+
+Upstream-Status: Inappropriate [embedded specific]
+Signed-off-by: James Minor <james.minor@ni.com>
+--- a/configure.pri
++++ b/configure.pri
+@@ -854,7 +854,7 @@ defineTest(qtConfOutput_preparePaths) {
+     export(config.qtbase.features.shared.available)
+ 
+     hostbindir_absolute_path = $$absolute_path($$config.rel_input.hostbindir, $$config.input.hostprefix)
+-    config.input.hostbindir_to_hostprefix = $$relative_path($$config.input.hostprefix, $$hostbindir_absolute_path)
++    config.input.hostbindir_to_hostprefix = $$relative_path($$config.input.extprefix, $$hostbindir_absolute_path)
+     config.input.hostbindir_to_extprefix = $$relative_path($$config.input.extprefix, $$hostbindir_absolute_path)
+ 
+     !isEmpty(PREFIX_COMPLAINTS) {
+@@ -889,11 +889,11 @@ defineTest(qtConfOutput_preparePaths) {
+     QT_CONFIGURE_STR_OFFSETS =
+     QT_CONFIGURE_STRS =
+ 
+-    addConfStr($$config.input.sysroot)
++    addConfStr("/")
+     addConfStr($$qmake_sysrootify)
+-    addConfStr($$config.rel_input.hostbindir)
+-    addConfStr($$config.rel_input.hostlibdir)
+-    addConfStr($$config.rel_input.hostdatadir)
++    addConfStr($$config.rel_input.bindir)
++    addConfStr($$config.rel_input.libdir)
++    addConfStr($$config.rel_input.datadir)
+     addConfStr($$XSPEC)
+     addConfStr($$[QMAKE_SPEC])
+ 
+@@ -902,7 +902,7 @@ defineTest(qtConfOutput_preparePaths) {
+         "static const char qt_configure_prefix_path_str  [12+512] = \"qt_prfxpath=$$config.input.prefix\";" \
+         "$${LITERAL_HASH}ifdef QT_BUILD_QMAKE" \
+         "static const char qt_configure_ext_prefix_path_str   [12+512] = \"qt_epfxpath=$$config.input.extprefix\";" \
+-        "static const char qt_configure_host_prefix_path_str  [12+512] = \"qt_hpfxpath=$$config.input.hostprefix\";" \
++        "static const char qt_configure_host_prefix_path_str  [12+512] = \"qt_hpfxpath=$$config.input.extprefix\";" \
+         "$${LITERAL_HASH}endif" \
+         "" \
+         "static const short qt_configure_str_offsets[] = {" \

--- a/recipes-qt/qt5/qtbase/0029-Remove-ptests-with-SRCDIR.patch
+++ b/recipes-qt/qt5/qtbase/0029-Remove-ptests-with-SRCDIR.patch
@@ -1,0 +1,57 @@
+Remove ptests that leak host paths via SRCDIR
+The host paths are not useful on the target and may cause security concerns.
+Some auto tests run as ptests include references to external resources via
+SRCDIR and fail today.
+
+Remove the problematic tests since they won't pass completely anyway.
+
+Upstream-Status: Inappropriate [embedded specific]
+Signed-off-by: James Minor <james.minor@ni.com>
+Index: git/tests/auto/corelib/tools/tools.pro
+===================================================================
+--- git.orig/tests/auto/corelib/tools/tools.pro
++++ git/tests/auto/corelib/tools/tools.pro
+@@ -36,7 +36,6 @@ SUBDIRS=\
+     qscopedvaluerollback \
+     qscopeguard \
+     qset \
+-    qsharedpointer \
+     qsize \
+     qsizef \
+     qstl \
+Index: git/tests/auto/other/other.pro
+===================================================================
+--- git.orig/tests/auto/other/other.pro
++++ git/tests/auto/other/other.pro
+@@ -4,7 +4,6 @@ QT_FOR_CONFIG += gui-private
+ SUBDIRS=\
+    compiler \
+    gestures \
+-   lancelot \
+    languagechange \
+    macgui \
+    #macnativeevents \
+Index: git/tests/auto/widgets/dialogs/dialogs.pro
+===================================================================
+--- git.orig/tests/auto/widgets/dialogs/dialogs.pro
++++ git/tests/auto/widgets/dialogs/dialogs.pro
+@@ -3,7 +3,6 @@ SUBDIRS=\
+    qcolordialog \
+    qdialog \
+    qerrormessage \
+-   qfiledialog \
+    qfiledialog2 \
+    qfilesystemmodel \
+    qfontdialog \
+Index: git/tests/auto/widgets/itemviews/itemviews.pro
+===================================================================
+--- git.orig/tests/auto/widgets/itemviews/itemviews.pro
++++ git/tests/auto/widgets/itemviews/itemviews.pro
+@@ -3,7 +3,6 @@ SUBDIRS=\
+    qabstractitemview \
+    qcolumnview \
+    qdatawidgetmapper \
+-   qdirmodel \
+    qfileiconprovider \
+    qheaderview \
+    qitemdelegate \

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -283,7 +283,8 @@ do_install:append() {
     echo "isEmpty(QMAKE_LINK_SHLIB): QMAKE_LINK_SHLIB = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf
     echo "isEmpty(QMAKE_LINK_C): QMAKE_LINK_C = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf
     echo "isEmpty(QMAKE_LINK_C_SHLIB): QMAKE_LINK_C_SHLIB = $OE_QMAKE_LINK_NO_SYSROOT" >> $conf
-    echo "isEmpty(QMAKE_LFLAGS): QMAKE_LFLAGS = ${OE_QMAKE_LDFLAGS}" >> $conf
+    # OE_QMAKE_LFLAGS contains path of the build host, which is not useful for the target.
+    echo "isEmpty(QMAKE_LFLAGS): QMAKE_LFLAGS = ${OE_QMAKE_LDFLAGS}" | sed -e 's/-fdebug-prefix-map=[^ ]*//g' | sed -e 's/-fmacro-prefix-map=[^ ]*//g' >> $conf
     echo "isEmpty(QMAKE_OBJCOPY): QMAKE_OBJCOPY = ${TARGET_PREFIX}objcopy" >> $conf
     echo "isEmpty(QMAKE_STRIP): QMAKE_STRIP = ${TARGET_PREFIX}strip" >> $conf
     echo "isEmpty(CC_host): CC_host = ${CC_host}" >> $conf

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -48,6 +48,7 @@ SRC_URI += "\
     file://0027-xkb-fix-build-with-libxkbcommon-1.6.0-and-later.patch \
     file://0001-CVE-2023-51714-qtbase-5.15.diff \
     file://0002-CVE-2023-51714-qtbase-5.15.diff \
+    file://0028-Remove-host-paths-from-qmake.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -49,6 +49,7 @@ SRC_URI += "\
     file://0001-CVE-2023-51714-qtbase-5.15.diff \
     file://0002-CVE-2023-51714-qtbase-5.15.diff \
     file://0028-Remove-host-paths-from-qmake.patch \
+    file://0029-Remove-ptests-with-SRCDIR.patch \
 "
 
 # Disable LTO for now, QT5 patches are being worked upstream, perhaps revisit with


### PR DESCRIPTION
Upstream commits to fix qtbase warnings (https://github.com/meta-qt5/meta-qt5/pull/559) got into `master-next`.
Cherry-pick them now instead of waiting for them to end up in `master`.

WI: [AB#2630975](https://dev.azure.com/ni/DevCentral/_workitems/edit/2630975)

### Testing
None (@jeminor already tested the changes before sending upstream).