### PR TITLE
qtnetworkauth_git.bb: add patch for CVE-2024-36048

### DIFF
--- a/recipes-qt/qt5/qtnetworkauth_git.bb
+++ b/recipes-qt/qt5/qtnetworkauth_git.bb
@@ -4,6 +4,10 @@ LIC_FILES_CHKSUM = " \
     file://LICENSE.FDL;md5=6d9f2a9af4c8b8c3c769f6cc1b6aaf7e \
 "
 
+SRC_URI += "\
+    file://CVE-2024-36048.diff \
+"
+
 require qt5.inc
 require qt5-git.inc
 

--- a/recipes-qt/qt5/qunetworkauth/CVE-2024-36048.diff
+++ b/recipes-qt/qt5/qunetworkauth/CVE-2024-36048.diff
@@ -1,0 +1,53 @@
+diff --git a/src/oauth/qabstractoauth.cpp b/src/oauth/qabstractoauth.cpp
+index f1ed2af..05b189a 100644
+--- a/src/oauth/qabstractoauth.cpp
++++ b/src/oauth/qabstractoauth.cpp
+@@ -37,7 +37,6 @@
+ #include <QtCore/qurl.h>
+ #include <QtCore/qpair.h>
+ #include <QtCore/qstring.h>
+-#include <QtCore/qdatetime.h>
+ #include <QtCore/qurlquery.h>
+ #include <QtCore/qjsondocument.h>
+ #include <QtCore/qmessageauthenticationcode.h>
+@@ -46,6 +45,9 @@
+ #include <QtNetwork/qnetworkaccessmanager.h>
+ #include <QtNetwork/qnetworkreply.h>
+ 
++#include <QtCore/qrandom.h>
++#include <QtCore/private/qlocking_p.h>
++
+ #include <random>
+ 
+ Q_DECLARE_METATYPE(QAbstractOAuth::Error)
+@@ -290,15 +292,19 @@ void QAbstractOAuthPrivate::setStatus(QAbstractOAuth::Status newStatus)
+     }
+ }
+ 
++static QBasicMutex prngMutex;
++Q_GLOBAL_STATIC_WITH_ARGS(std::mt19937, prng, (*QRandomGenerator::system()))
++
+ QByteArray QAbstractOAuthPrivate::generateRandomString(quint8 length)
+ {
+-    const char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+-    static std::mt19937 randomEngine(QDateTime::currentDateTime().toMSecsSinceEpoch());
++    constexpr char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+     std::uniform_int_distribution<int> distribution(0, sizeof(characters) - 2);
+     QByteArray data;
+     data.reserve(length);
++    auto lock = qt_unique_lock(prngMutex);
+     for (quint8 i = 0; i < length; ++i)
+-        data.append(characters[distribution(randomEngine)]);
++        data.append(characters[distribution(*prng)]);
++    lock.unlock();
+     return data;
+ }
+ 
+@@ -614,6 +620,7 @@ void QAbstractOAuth::resourceOwnerAuthorization(const QUrl &url, const QVariantM
+ }
+ 
+ /*!
++    \threadsafe
+     Generates a random string which could be used as state or nonce.
+     The parameter \a length determines the size of the generated
+     string.


### PR DESCRIPTION
[AB#3200615](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3200615)

[CVE-2024-36048](https://nvd.nist.gov/vuln/detail/CVE-2024-36048) needs to be addressed, and the fix is present [here](https://download.qt.io/official_releases/qt/5.15/CVE-2024-36048-qtnetworkauth-5.15.diff).


The patch at this locations were downloaded and added as part of this PR, and has been made part of the recipe qtnetworkauth_git.bb.

I have tested by building the recipe and the base system image.