### PR TITLE
qtnetworkauth: Pick CVE-2024-36048 fix

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -57,6 +57,8 @@ SRC_URI += " \
     file://0025-Bootstrap-without-linkat-feature.patch \
 "
 
+CVE_STATUS[CVE-2024-36048] = "cpe-incorrect: this applies to qtnetworkauth"
+
 CLEANBROKEN = "1"
 
 XPLATFORM:toolchain-clang = "linux-oe-clang"

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -53,6 +53,8 @@ SRC_URI += "\
     file://CVE-2024-39936-qtbase-5.15.patch \
 "
 
+CVE_STATUS[CVE-2024-36048] = "cpe-incorrect: this applies to qtnetworkauth"
+
 # usually pulled by one of the optional dependencies in PACKAGECONFIG, but with very limited PACKAGECONFIG fails with:
 # src/corelib/io/qresource.cpp:68:12: fatal error: zstd.h: No such file or directory
 DEPENDS = "zstd"

--- a/recipes-qt/qt5/qtnetworkauth/CVE-2024-36048-qtnetworkauth-5.15.diff
+++ b/recipes-qt/qt5/qtnetworkauth/CVE-2024-36048-qtnetworkauth-5.15.diff
@@ -1,0 +1,53 @@
+diff --git a/src/oauth/qabstractoauth.cpp b/src/oauth/qabstractoauth.cpp
+index f1ed2af..05b189a 100644
+--- a/src/oauth/qabstractoauth.cpp
++++ b/src/oauth/qabstractoauth.cpp
+@@ -37,7 +37,6 @@
+ #include <QtCore/qurl.h>
+ #include <QtCore/qpair.h>
+ #include <QtCore/qstring.h>
+-#include <QtCore/qdatetime.h>
+ #include <QtCore/qurlquery.h>
+ #include <QtCore/qjsondocument.h>
+ #include <QtCore/qmessageauthenticationcode.h>
+@@ -46,6 +45,9 @@
+ #include <QtNetwork/qnetworkaccessmanager.h>
+ #include <QtNetwork/qnetworkreply.h>
+ 
++#include <QtCore/qrandom.h>
++#include <QtCore/private/qlocking_p.h>
++
+ #include <random>
+ 
+ Q_DECLARE_METATYPE(QAbstractOAuth::Error)
+@@ -290,15 +292,19 @@ void QAbstractOAuthPrivate::setStatus(QAbstractOAuth::Status newStatus)
+     }
+ }
+ 
++static QBasicMutex prngMutex;
++Q_GLOBAL_STATIC_WITH_ARGS(std::mt19937, prng, (*QRandomGenerator::system()))
++
+ QByteArray QAbstractOAuthPrivate::generateRandomString(quint8 length)
+ {
+-    const char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+-    static std::mt19937 randomEngine(QDateTime::currentDateTime().toMSecsSinceEpoch());
++    constexpr char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+     std::uniform_int_distribution<int> distribution(0, sizeof(characters) - 2);
+     QByteArray data;
+     data.reserve(length);
++    auto lock = qt_unique_lock(prngMutex);
+     for (quint8 i = 0; i < length; ++i)
+-        data.append(characters[distribution(randomEngine)]);
++        data.append(characters[distribution(*prng)]);
++    lock.unlock();
+     return data;
+ }
+ 
+@@ -614,6 +620,7 @@ void QAbstractOAuth::resourceOwnerAuthorization(const QUrl &url, const QVariantM
+ }
+ 
+ /*!
++    \threadsafe
+     Generates a random string which could be used as state or nonce.
+     The parameter \a length determines the size of the generated
+     string.

--- a/recipes-qt/qt5/qtnetworkauth_git.bb
+++ b/recipes-qt/qt5/qtnetworkauth_git.bb
@@ -7,6 +7,10 @@ LIC_FILES_CHKSUM = " \
 require qt5.inc
 require qt5-git.inc
 
+SRC_URI += "\
+    file://CVE-2024-36048-qtnetworkauth-5.15.diff \
+"
+
 DEPENDS += "qtbase"
 
 SRCREV = "ed2291d454fac207f6b1555d30b9227e51be611b"


### PR DESCRIPTION
Apply upstream's patch for CVE-2024-36048 to qtnetworkauth.

Mark CVE-2024-36048 as `cpe-incorrect` for `qtbase` and `qtbase-native`.

### Justification
 [AB#3200615](https://dev.azure.com/ni/DevCentral/_workitems/edit/3200615)

### Testing
- [x] `bitbake qtnetworkauth`, `bitbake qtbase` succeed
- [x] Verified with `bitbake -e qtnetworkauth` that `SRC_URI` now contains the patch.
- [x] Ran `bitbake -c do_patch qtnetworkauth` and verified patch is applied.
- [x] With `INHERIT += "cve-check"` set in `conf/local.conf`, `bitbake qtnetworkauth` shows the CVE as patched.
- [x] With `INHERIT += "cve-check"` set in `conf/local.conf`, `bitbake qtbase` and `bitbake qtbase-native` shows the CVE as `Ignored`.

### Notes
- Needs to be cherry-picked to `nilrt/25.8/scarthgap`