### PR TITLE
Cherry-pick NI commits to nilrt/master/next

### DIFF
--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -41,6 +41,7 @@ SRC_URI += "\
     file://0021-rcc-Just-dcument-file-name-without-full-path-to-redu.patch \
     file://0022-testlib-don-t-track-the-build-or-source-directories.patch \
     file://0023-qdbusxml2cpp-don-t-track-command-line.patch \
+    file://CVE-2024-39936-qtbase-5.15.patch \
 "
 
 # common for qtbase-native and nativesdk-qtbase

--- a/recipes-qt/qt5/qtbase-native_git.bb
+++ b/recipes-qt/qt5/qtbase-native_git.bb
@@ -57,6 +57,8 @@ SRC_URI += " \
     file://0025-Bootstrap-without-linkat-feature.patch \
 "
 
+CVE_STATUS[CVE-2024-36048] = "cpe-incorrect: this applies to qtnetworkauth"
+
 CLEANBROKEN = "1"
 
 XPLATFORM:toolchain-clang = "linux-oe-clang"

--- a/recipes-qt/qt5/qtbase/CVE-2024-39936-qtbase-5.15.patch
+++ b/recipes-qt/qt5/qtbase/CVE-2024-39936-qtbase-5.15.patch
@@ -1,0 +1,136 @@
+diff --git a/src/network/access/qhttp2protocolhandler.cpp b/src/network/access/qhttp2protocolhandler.cpp
+index d1b5dfda2e2..ee04a1856c6 100644
+--- a/src/network/access/qhttp2protocolhandler.cpp
++++ b/src/network/access/qhttp2protocolhandler.cpp
+@@ -375,12 +375,12 @@ bool QHttp2ProtocolHandler::sendRequest()
+         }
+     }
+ 
+-    if (!prefaceSent && !sendClientPreface())
+-        return false;
+-
+     if (!requests.size())
+         return true;
+ 
++    if (!prefaceSent && !sendClientPreface())
++        return false;
++
+     m_channel->state = QHttpNetworkConnectionChannel::WritingState;
+     // Check what was promised/pushed, maybe we do not have to send a request
+     // and have a response already?
+diff --git a/src/network/access/qhttpnetworkconnectionchannel.cpp b/src/network/access/qhttpnetworkconnectionchannel.cpp
+index bd2f32e3528..6f3bd807a09 100644
+--- a/src/network/access/qhttpnetworkconnectionchannel.cpp
++++ b/src/network/access/qhttpnetworkconnectionchannel.cpp
+@@ -255,6 +255,10 @@ void QHttpNetworkConnectionChannel::abort()
+ bool QHttpNetworkConnectionChannel::sendRequest()
+ {
+     Q_ASSERT(!protocolHandler.isNull());
++    if (waitingForPotentialAbort) {
++        needInvokeSendRequest = true;
++        return false; // this return value is unused
++    }
+     return protocolHandler->sendRequest();
+ }
+ 
+@@ -267,21 +271,28 @@ bool QHttpNetworkConnectionChannel::sendRequest()
+ void QHttpNetworkConnectionChannel::sendRequestDelayed()
+ {
+     QMetaObject::invokeMethod(this, [this] {
+-        Q_ASSERT(!protocolHandler.isNull());
+         if (reply)
+-            protocolHandler->sendRequest();
++            sendRequest();
+     }, Qt::ConnectionType::QueuedConnection);
+ }
+ 
+ void QHttpNetworkConnectionChannel::_q_receiveReply()
+ {
+     Q_ASSERT(!protocolHandler.isNull());
++    if (waitingForPotentialAbort) {
++        needInvokeReceiveReply = true;
++        return;
++    }
+     protocolHandler->_q_receiveReply();
+ }
+ 
+ void QHttpNetworkConnectionChannel::_q_readyRead()
+ {
+     Q_ASSERT(!protocolHandler.isNull());
++    if (waitingForPotentialAbort) {
++        needInvokeReadyRead = true;
++        return;
++    }
+     protocolHandler->_q_readyRead();
+ }
+ 
+@@ -1289,7 +1300,18 @@ void QHttpNetworkConnectionChannel::_q_encrypted()
+             // Similar to HTTP/1.1 counterpart below:
+             const auto &pairs = spdyRequestsToSend.values(); // (request, reply)
+             const auto &pair = pairs.first();
++            waitingForPotentialAbort = true;
+             emit pair.second->encrypted();
++
++            // We don't send or handle any received data until any effects from
++            // emitting encrypted() have been processed. This is necessary
++            // because the user may have called abort(). We may also abort the
++            // whole connection if the request has been aborted and there is
++            // no more requests to send.
++            QMetaObject::invokeMethod(this,
++                                      &QHttpNetworkConnectionChannel::checkAndResumeCommunication,
++                                      Qt::QueuedConnection);
++
+             // In case our peer has sent us its settings (window size, max concurrent streams etc.)
+             // let's give _q_receiveReply a chance to read them first ('invokeMethod', QueuedConnection).
+             QMetaObject::invokeMethod(connection, "_q_startNextRequest", Qt::QueuedConnection);
+@@ -1307,6 +1329,26 @@ void QHttpNetworkConnectionChannel::_q_encrypted()
+     }
+ }
+ 
++void QHttpNetworkConnectionChannel::checkAndResumeCommunication()
++{
++    Q_ASSERT(connection->connectionType() > QHttpNetworkConnection::ConnectionTypeHTTP);
++
++    // Because HTTP/2 requires that we send a SETTINGS frame as the first thing we do, and respond
++    // to a SETTINGS frame with an ACK, we need to delay any handling until we can ensure that any
++    // effects from emitting encrypted() have been processed.
++    // This function is called after encrypted() was emitted, so check for changes.
++
++    if (!reply && spdyRequestsToSend.isEmpty())
++        abort();
++    waitingForPotentialAbort = false;
++    if (needInvokeReadyRead)
++        _q_readyRead();
++    if (needInvokeReceiveReply)
++        _q_receiveReply();
++    if (needInvokeSendRequest)
++        sendRequest();
++}
++
+ void QHttpNetworkConnectionChannel::requeueSpdyRequests()
+ {
+     QList<HttpMessagePair> spdyPairs = spdyRequestsToSend.values();
+diff --git a/src/network/access/qhttpnetworkconnectionchannel_p.h b/src/network/access/qhttpnetworkconnectionchannel_p.h
+index 6be0c51f9fe..613fda7bc31 100644
+--- a/src/network/access/qhttpnetworkconnectionchannel_p.h
++++ b/src/network/access/qhttpnetworkconnectionchannel_p.h
+@@ -107,6 +107,10 @@ public:
+     QAbstractSocket *socket;
+     bool ssl;
+     bool isInitialized;
++    bool waitingForPotentialAbort = false;
++    bool needInvokeReceiveReply = false;
++    bool needInvokeReadyRead = false;
++    bool needInvokeSendRequest = false;
+     ChannelState state;
+     QHttpNetworkRequest request; // current request, only used for HTTP
+     QHttpNetworkReply *reply; // current reply for this request, only used for HTTP
+@@ -187,6 +191,8 @@ public:
+     void closeAndResendCurrentRequest();
+     void resendCurrentRequest();
+ 
++    void checkAndResumeCommunication();
++
+     bool isSocketBusy() const;
+     bool isSocketWriting() const;
+     bool isSocketWaiting() const;

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -44,6 +44,7 @@ SRC_URI += "\
     file://0028-Remove-host-paths-from-qmake.patch \
     file://0029-Remove-ptests-with-SRCDIR.patch \
     file://CVE-2024-25580.patch \
+    file://CVE-2024-39936-qtbase-5.15.patch \
 "
 
 # usually pulled by one of the optional dependencies in PACKAGECONFIG, but with very limited PACKAGECONFIG fails with:

--- a/recipes-qt/qt5/qtbase_git.bb
+++ b/recipes-qt/qt5/qtbase_git.bb
@@ -47,6 +47,8 @@ SRC_URI += "\
     file://CVE-2024-39936-qtbase-5.15.patch \
 "
 
+CVE_STATUS[CVE-2024-36048] = "cpe-incorrect: this applies to qtnetworkauth"
+
 # usually pulled by one of the optional dependencies in PACKAGECONFIG, but with very limited PACKAGECONFIG fails with:
 # src/corelib/io/qresource.cpp:68:12: fatal error: zstd.h: No such file or directory
 DEPENDS = "zstd"

--- a/recipes-qt/qt5/qtnetworkauth/CVE-2024-36048-qtnetworkauth-5.15.diff
+++ b/recipes-qt/qt5/qtnetworkauth/CVE-2024-36048-qtnetworkauth-5.15.diff
@@ -1,0 +1,53 @@
+diff --git a/src/oauth/qabstractoauth.cpp b/src/oauth/qabstractoauth.cpp
+index f1ed2af..05b189a 100644
+--- a/src/oauth/qabstractoauth.cpp
++++ b/src/oauth/qabstractoauth.cpp
+@@ -37,7 +37,6 @@
+ #include <QtCore/qurl.h>
+ #include <QtCore/qpair.h>
+ #include <QtCore/qstring.h>
+-#include <QtCore/qdatetime.h>
+ #include <QtCore/qurlquery.h>
+ #include <QtCore/qjsondocument.h>
+ #include <QtCore/qmessageauthenticationcode.h>
+@@ -46,6 +45,9 @@
+ #include <QtNetwork/qnetworkaccessmanager.h>
+ #include <QtNetwork/qnetworkreply.h>
+ 
++#include <QtCore/qrandom.h>
++#include <QtCore/private/qlocking_p.h>
++
+ #include <random>
+ 
+ Q_DECLARE_METATYPE(QAbstractOAuth::Error)
+@@ -290,15 +292,19 @@ void QAbstractOAuthPrivate::setStatus(QAbstractOAuth::Status newStatus)
+     }
+ }
+ 
++static QBasicMutex prngMutex;
++Q_GLOBAL_STATIC_WITH_ARGS(std::mt19937, prng, (*QRandomGenerator::system()))
++
+ QByteArray QAbstractOAuthPrivate::generateRandomString(quint8 length)
+ {
+-    const char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+-    static std::mt19937 randomEngine(QDateTime::currentDateTime().toMSecsSinceEpoch());
++    constexpr char characters[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+     std::uniform_int_distribution<int> distribution(0, sizeof(characters) - 2);
+     QByteArray data;
+     data.reserve(length);
++    auto lock = qt_unique_lock(prngMutex);
+     for (quint8 i = 0; i < length; ++i)
+-        data.append(characters[distribution(randomEngine)]);
++        data.append(characters[distribution(*prng)]);
++    lock.unlock();
+     return data;
+ }
+ 
+@@ -614,6 +620,7 @@ void QAbstractOAuth::resourceOwnerAuthorization(const QUrl &url, const QVariantM
+ }
+ 
+ /*!
++    \threadsafe
+     Generates a random string which could be used as state or nonce.
+     The parameter \a length determines the size of the generated
+     string.

--- a/recipes-qt/qt5/qtnetworkauth_git.bb
+++ b/recipes-qt/qt5/qtnetworkauth_git.bb
@@ -7,6 +7,10 @@ LIC_FILES_CHKSUM = " \
 require qt5.inc
 require qt5-git.inc
 
+SRC_URI += "\
+    file://CVE-2024-36048-qtnetworkauth-5.15.diff \
+"
+
 DEPENDS += "qtbase"
 
 SRCREV = "b7cb0184f4f7d45f1e711a4ab5a1b54817402f98"


### PR DESCRIPTION
This PR cherry-picks NI-specific commits from the nilrt/master/scarthgap branch into the nilrt/master/next branch of the **meta-qt5** layer.
[AB#3039674](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039674)

**Below commits were dropped either because they were already present in the upstream.**
[6aafe79](https://github.com/ni/meta-qt5/commit/6aafe7921bb81de6f859e0f335e89b29c2e75ad6) - qtbase: Remove ptests that use SRCDIR.
[da1bdc6](https://github.com/ni/meta-qt5/commit/da1bdc6dd0404a76d9c513abbe504d9967bc1c6e) - qtbase: Remove host paths from qmake.
[7cdcf84](https://github.com/ni/meta-qt5/commit/7cdc8f4d8ad9aa68b796628443a66accbf87500f) - qtbase: Remove additional path of the build host from qmake.conf.
[bb3672b](https://github.com/ni/meta-qt5/commit/bb3672ba057f53e6be7b18d408893f19f6fec7bd) - layer.conf: Mark scarthgap as only compatible release.
[444a50](https://github.com/ni/meta-qt5/commit/444a50abe58b0e0566090d9b9d26fc3f055b213a) - nativesdk-packagegroup-qt5-toolchain-host: Use inherit_defer for nativesdk.



**Below commits doesn't had any conflicts.**
[bbd7ffb](https://github.com/ni/meta-qt5/commit/bdb7ffba59bd6673c0f9a13dbd80c49aa9f51f9e) - qtnetworkauth: Pick CVE-2024-36048 fix.
[8b43634](https://github.com/ni/meta-qt5/commit/8b436348992e423c981a50e5e3f06999fa1e23f8) - qtbase: Mark [CVE-2024-36048](https://github.com/advisories/GHSA-r8x8-rv8c-j266) as cpe-incorrect


**Following commit had a conflict that had to be manually resolved.**
[32763fe](https://github.com/ni/meta-qt5/pull/21/commits/32763fe337ce2667151d98b588e28c83ace0dd06) - (RFC) qtbase: Pick CVE-2024-39936 fix . Check new commit [03d2652](https://github.com/ni/meta-qt5/pull/26/commits/03d26528b7fca707f8d1f9f345c569081987310e) for details.
