### PR TITLE
qtbase-native: add Upstream-Status to existing CVE-2024-39936 patch

### DIFF
--- a/recipes-qt/qt5/qtbase/CVE-2024-39936-qtbase-5.15.patch
+++ b/recipes-qt/qt5/qtbase/CVE-2024-39936-qtbase-5.15.patch
@@ -1,3 +1,8 @@
+Upstream-Status: Backport [Qt 5.15 LTS security fix]
+
+[shubhanshumt26: Added Upstream-Status tag]
+Signed-off-by: Shubhanshu Mani Tripathi <shubhanshu.mani.tripathi@emerson.com>
+
 diff --git a/src/network/access/qhttp2protocolhandler.cpp b/src/network/access/qhttp2protocolhandler.cpp
 index d1b5dfda2e2..ee04a1856c6 100644
 --- a/src/network/access/qhttp2protocolhandler.cpp


### PR DESCRIPTION
### Summary
This PR Adds a missing `Upstream-Status` tag to a `CVE-2024-39936-qtbase-5.15.patch` to avoid QA warnings.

### Justification
[AB#3039672](https://dev.azure.com/ni/94b22d7b-ad7b-4f5e-88f0-867910f91c94/_workitems/edit/3039672)

### Testing

- `qtbase-native` recipe builds successfully